### PR TITLE
Fix polarisation order.

### DIFF
--- a/src/chromatix/functional/polarizers.py
+++ b/src/chromatix/functional/polarizers.py
@@ -2,6 +2,7 @@ from ..field import VectorField
 from typing import Union
 from chex import Array
 import jax.numpy as jnp
+from chromatix.utils.utils import matvec
 
 __all__ = [
     # General functions
@@ -98,10 +99,8 @@ def polarizer(
     """
     # Invert the axes as our order is zyx
     LP = jnp.array([[0, 0, 0], [0, J11, J10], [0, J01, J00]])
-
-    # We need to add empty axis for batched matmul
-    u = jnp.matmul(LP, field.u[..., None]).squeeze(-1)
-    return field.replace(u=u)
+    LP = LP / jnp.linalg.norm(LP)
+    return field.replace(u=matvec(LP, field.u))
 
 
 def linear_polarizer(field: VectorField, angle: float) -> VectorField:

--- a/src/chromatix/functional/polarizers.py
+++ b/src/chromatix/functional/polarizers.py
@@ -98,7 +98,10 @@ def polarizer(
     """
     # Invert the axes as our order is zyx
     LP = jnp.array([[0, 0, 0], [0, J11, J10], [0, J01, J00]])
-    return field.replace(u=jnp.dot(field.u, LP))
+
+    # We need to add empty axis for batched matmul
+    u = jnp.matmul(LP, field.u[..., None]).squeeze(-1)
+    return field.replace(u=u)
 
 
 def linear_polarizer(field: VectorField, angle: float) -> VectorField:

--- a/src/chromatix/utils/utils.py
+++ b/src/chromatix/utils/utils.py
@@ -127,3 +127,10 @@ def l1_norm(a: Array, axis: Union[int, Tuple[int, ...]] = 0) -> Array:
 def linf_norm(a: Array, axis: Union[int, Tuple[int, ...]] = 0) -> Array:
     """Max absolute value, i.e. `max(|x|, |y|)`."""
     return jnp.max(jnp.abs(a), axis=axis)
+
+
+def matvec(x: Array, y: Array) -> Array:
+    """Implements batched matrix - vector multiplication.
+    Mostly used in polarisation calculations.
+    Example [..., N, M] x [...., M] -> [...., N]"""
+    return jnp.matmul(x, y[..., None]).squeeze(-1)

--- a/tests/test_polarizers.py
+++ b/tests/test_polarizers.py
@@ -4,6 +4,7 @@ from chromatix import VectorField
 from functools import partial
 from chex import assert_axis_dimension
 import pytest
+import numpy as np
 
 
 def test_inits():
@@ -46,36 +47,71 @@ def test_linear_polarizer(E0, angle, power):
 
 
 def test_left_circular_polarizer():
+    # right circular light through left ciruclar
+    # polariser shouldnt give any output
     field = cf.plane_wave(
         (512, 512),
         1.0,
         0.532,
         1.0,
-        amplitude=cf.linear(0),
+        amplitude=cf.right_circular(),
         power=1.0,
         pupil=partial(cf.square_pupil, w=10.0),
         scalar=False,
     )
-
     field = cf.left_circular_polarizer(field)
     assert_axis_dimension(field.u, -1, 3)
-    # TODO: add another test
+    assert np.allclose(field.power, 0.0)
 
-
-def test_right_circular_polarizer():
+    # Right circular light through right ciruclar
+    # polariser should return right circular light
     field = cf.plane_wave(
         (512, 512),
         1.0,
         0.532,
         1.0,
-        amplitude=cf.linear(0),
+        amplitude=cf.left_circular(),
+        power=1.0,
+        pupil=partial(cf.square_pupil, w=10.0),
+        scalar=False,
+    )
+    field_after = cf.left_circular_polarizer(field)
+    assert_axis_dimension(field.u, -1, 3)
+    assert np.allclose(field.u, field_after.u)
+
+
+def test_right_circular_polarizer():
+    # Left circular light through right ciruclar
+    # polariser shouldnt give any output
+    field = cf.plane_wave(
+        (512, 512),
+        1.0,
+        0.532,
+        1.0,
+        amplitude=cf.left_circular(),
         power=1.0,
         pupil=partial(cf.square_pupil, w=10.0),
         scalar=False,
     )
     field = cf.right_circular_polarizer(field)
     assert_axis_dimension(field.u, -1, 3)
-    # TODO: add another test
+    assert np.allclose(field.power, 0.0)
+
+    # Right circular light through right ciruclar
+    # polariser should return right circular light
+    field = cf.plane_wave(
+        (512, 512),
+        1.0,
+        0.532,
+        1.0,
+        amplitude=cf.right_circular(),
+        power=1.0,
+        pupil=partial(cf.square_pupil, w=10.0),
+        scalar=False,
+    )
+    field_after = cf.right_circular_polarizer(field)
+    assert_axis_dimension(field.u, -1, 3)
+    assert np.allclose(field.u, field_after.u)
 
 
 def test_quarter_waveplate():


### PR DESCRIPTION
This fixes two things in the polarisation, as suggested by @gschlafly in #116 
1. It changes the order of the matrix-vector product. Previous behaviour was incorrect for asymmetric matrices.
2. The polarisation matrices weren't normalised, leading to an increase in power. Now they're properly normalised
3. Added tests for all this under left/right circular polarisers.

