### PR TITLE
Check shapes sources

### DIFF
--- a/src/chromatix/functional/sources.py
+++ b/src/chromatix/functional/sources.py
@@ -56,6 +56,13 @@ def point_source(
         epsilon: Value added to denominators for numerical stability.
     """
     create = ScalarField.create if scalar else VectorField.create
+    # If scalar, last axis should 1, else 3.
+    amplitude = jnp.atleast_1d(amplitude)
+    if scalar:
+        assert_axis_dimension(amplitude, -1, 1)
+    else:
+        assert_axis_dimension(amplitude, -1, 3)
+
     field = create(dx, spectrum, spectral_density, shape=shape)
     z = _broadcast_1d_to_innermost_batch(z, field.ndim)
     amplitude = _broadcast_1d_to_polarization(amplitude, field.ndim)
@@ -108,6 +115,14 @@ def objective_point_source(
             ``VectorField`` (if False). Defaults to True.
     """
     create = ScalarField.create if scalar else VectorField.create
+
+    # If scalar, last axis should 1, else 3.
+    amplitude = jnp.atleast_1d(amplitude)
+    if scalar:
+        assert_axis_dimension(amplitude, -1, 1)
+    else:
+        assert_axis_dimension(amplitude, -1, 3)
+
     field = create(dx, spectrum, spectral_density, shape=shape)
     z = _broadcast_1d_to_innermost_batch(z, field.ndim)
     amplitude = _broadcast_1d_to_polarization(amplitude, field.ndim)
@@ -156,6 +171,14 @@ def plane_wave(
             ``VectorField`` (if False). Defaults to True.
     """
     create = ScalarField.create if scalar else VectorField.create
+
+    # If scalar, last axis should 1, else 3.
+    amplitude = jnp.atleast_1d(amplitude)
+    if scalar:
+        assert_axis_dimension(amplitude, -1, 1)
+    else:
+        assert_axis_dimension(amplitude, -1, 3)
+
     field = create(dx, spectrum, spectral_density, shape=shape)
     kykx = _broadcast_1d_to_grid(kykx, field.ndim)
     amplitude = _broadcast_1d_to_polarization(amplitude, field.ndim)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -8,56 +8,76 @@ import pytest
 from chex import assert_shape
 
 
-@pytest.mark.parametrize(
-    "power, shape, pupil",
-    [
-        (1.0, (512, 512), partial(cf.circular_pupil, w=10.0)),
-        (100.0, (256, 256), None),
-    ],
-)
-def test_plane_wave(power, shape, pupil):
-    field = cf.plane_wave(shape, 0.1, 0.532, 1.0, power=power, pupil=pupil)
-
-    assert jnp.allclose(field.power, power)
-    assert_shape(field.u, (1, *shape, 1, 1))
-
-
-@pytest.mark.parametrize(
-    "power, amplitude, shape, pupil",
-    [
-        (1.0, cf.linear(jnp.pi / 2), (512, 512), partial(cf.circular_pupil, w=10.0)),
-        (100.0, cf.left_circular(), (256, 256), None),
-    ],
-)
-def test_plane_wave_vectorial(power, amplitude, shape, pupil):
-    field = cf.plane_wave(
-        shape,
-        0.1,
-        0.532,
-        1.0,
-        power=power,
-        amplitude=amplitude,
-        pupil=pupil,
-        scalar=False,
+class TestPlaneWave:
+    @pytest.mark.parametrize(
+        "power, shape, pupil",
+        [
+            (1.0, (512, 512), partial(cf.circular_pupil, w=10.0)),
+            (100.0, (256, 256), None),
+        ],
     )
+    def test_scalar(self, power, shape, pupil):
+        field = cf.plane_wave(shape, 0.1, 0.532, 1.0, power=power, pupil=pupil)
 
-    assert jnp.allclose(field.power, power)
-    assert_shape(field.u, (1, *shape, 1, 3))
+        assert jnp.allclose(field.power, power)
+        assert_shape(field.u, (1, *shape, 1, 1))
+
+    @pytest.mark.parametrize(
+        "power, amplitude, shape, pupil",
+        [
+            (
+                1.0,
+                cf.linear(jnp.pi / 2),
+                (512, 512),
+                partial(cf.circular_pupil, w=10.0),
+            ),
+            (100.0, cf.left_circular(), (256, 256), None),
+        ],
+    )
+    def test_vectorial(self, power, amplitude, shape, pupil):
+        field = cf.plane_wave(
+            shape,
+            0.1,
+            0.532,
+            1.0,
+            power=power,
+            amplitude=amplitude,
+            pupil=pupil,
+            scalar=False,
+        )
+
+        assert jnp.allclose(field.power, power)
+        assert_shape(field.u, (1, *shape, 1, 3))
+
+    @pytest.mark.parametrize(
+        "amplitude, scalar",
+        [
+            (jnp.ones((2,)), True),
+            (jnp.ones((2,)), False),
+            (jnp.ones((1,)), False),
+            (jnp.ones((3,)), True),
+        ],
+    )
+    def test_wrong_amplitude_size(self, amplitude: Array, scalar: bool):
+        # Using wrong shape for amplitude should raise Assertion error
+        with pytest.raises(AssertionError):
+            _ = cf.plane_wave(
+                (256, 256),
+                0.1,
+                0.532,
+                1.0,
+                amplitude=amplitude,
+                scalar=scalar,
+                power=1.0,
+            )
 
 
 class TestObjectivePointSource:
     @pytest.mark.parametrize(
-        "power, z, shape, pupil",
-        [
-            (1.0, 0.5, (512, 512), partial(cf.square_pupil, w=10.0)),
-            (100.0, 1.0, (256, 256), None),
-            (20.0, 2, (256, 512), None),  # should work for z =0
-        ],
+        "power, z, shape",
+        [(1.0, 0.5, (512, 512)), (100.0, 1.0, (256, 256)), (50, 0.0, (256, 512))],
     )
-    @pytest.mark.parametrize(
-        "power, z, shape", [(1.0, 0.5, (512, 512)), (100.0, 1.0, (256, 256))]
-    )
-    def test_scalar(power, z, shape):
+    def test_scalar(self, power, z, shape):
         field = cf.objective_point_source(
             shape, 0.1, 0.532, 1.0, z, 100.0, 1.33, NA=0.8, power=power
         )
@@ -93,17 +113,18 @@ class TestObjectivePointSource:
     def test_wrong_amplitude_size(self, amplitude: Array, scalar: bool):
         # Using wrong shape for amplitude should raise Assertion error
         with pytest.raises(AssertionError):
-            _ = cf.point_source(
+            _ = cf.objective_point_source(
                 (256, 256),
                 0.1,
                 0.532,
                 1.0,
                 1.0,
+                100,
+                1.0,
                 1.33,
                 amplitude=amplitude,
                 scalar=scalar,
                 power=1.0,
-                pupil=None,
             )
 
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -67,3 +67,60 @@ def test_objective_point_source(power, z, shape):
 
     assert jnp.allclose(field.power, power)
     assert_shape(field.u, (1, *shape, 1, 1))
+
+
+def test_point_source_wrong_size():
+    with pytest.raises(AssertionError) as e_info:
+        field = cf.point_source(
+            (256, 256),
+            0.1,
+            0.532,
+            1.0,
+            1.0,
+            1.33,
+            amplitude=jnp.array([1.0, 1.0]),
+            scalar=True,
+            power=1.0,
+            pupil=None,
+        )
+    with pytest.raises(AssertionError) as e_info:
+        field = cf.point_source(
+            (256, 256),
+            0.1,
+            0.532,
+            1.0,
+            1.0,
+            1.33,
+            amplitude=jnp.array([1.0, 1.0]),
+            scalar=False,
+            power=1.0,
+            pupil=None,
+        )
+
+    with pytest.raises(AssertionError) as e_info:
+        field = cf.point_source(
+            (256, 256),
+            0.1,
+            0.532,
+            1.0,
+            1.0,
+            1.33,
+            amplitude=jnp.array([1.0, 1.0, 1.0]),
+            scalar=True,
+            power=1.0,
+            pupil=None,
+        )
+
+    with pytest.raises(AssertionError) as e_info:
+        field = cf.point_source(
+            (256, 256),
+            0.1,
+            0.532,
+            1.0,
+            1.0,
+            1.33,
+            amplitude=1.0,
+            scalar=False,
+            power=1.0,
+            pupil=None,
+        )


### PR DESCRIPTION
Sources now raise an error when giving in wrong amplitude vector, per #112.


This also adds tests for that and reorders them a little bit.