### PR TITLE
Fix ruff version to `0.9.0` and add pre-commit setup info for ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.9.0
+  hooks:
+    # Run the linter.
+    - id: ruff
+    # Run the formatter.
+    - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ or for an editable install for development, first clone the repository and then 
 $ git clone https://github.com/chromatix-team/chromatix
 $ cd chromatix
 $ pip install -e .
+# install dependencies for development
+$ pip install pytest ruff pre-commit
+# install pre-commit hooks for formatting
+pre-commit install
+# test
+$ pytest
 ```
 Check out [the documentation](https://chromatix.readthedocs.io/en/latest/installing/) for more details on installation.
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -46,6 +46,12 @@ or for an editable install for development, first clone the repository and then 
 $ git clone https://github.com/chromatix-team/chromatix
 $ cd chromatix
 $ pip install -e .
+# install dependencies for development
+$ pip install pytest ruff pre-commit
+# install pre-commit hooks for formatting
+pre-commit install
+# test
+$ pytest
 ```
 Editable installations for development are recommended if you would like to
 make changes to the internals of Chromatix or add new features (pull requests
@@ -59,6 +65,7 @@ as [`uv`](https://docs.astral.sh/uv/). After installing `uv`, you can run the
 following commands for an editable install and to run the unit tests:
 ```bash
 $ uv sync --extra dev
+$ uv run pre-commit install
 $ uv run pytest
 ```
 A virtual environment is created in `.venv`. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = ["jax >= 0.4.1", "einops >= 0.6.0", "flax >= 0.6.3", "chex>=0.1.5
 version = "0.3.0"
 
 [project.optional-dependencies]
-dev = ["mypy>= 0.991", "pytest>=7.2.0", "ruff >= 0.4.8"]
+dev = ["mypy>= 0.991", "pytest>=7.2.0", "ruff==0.9.0"]
 docs = ["mkdocs >= 1.4.2", "mkdocs-material >= 9.0.6", "mkdocstrings-python >= 0.8.3", "mkdocs-jupyter"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = ["jax >= 0.4.1", "einops >= 0.6.0", "flax >= 0.6.3", "chex>=0.1.5
 version = "0.3.0"
 
 [project.optional-dependencies]
-dev = ["mypy>= 0.991", "pytest>=7.2.0", "ruff==0.9.0"]
+dev = ["mypy>= 0.991", "pytest>=7.2.0", "ruff==0.9.0", "pre-commit>=4.0.0"]
 docs = ["mkdocs >= 1.4.2", "mkdocs-material >= 9.0.6", "mkdocstrings-python >= 0.8.3", "mkdocs-jupyter"]
 
 [tool.ruff]

--- a/src/chromatix/elements/phase_masks.py
+++ b/src/chromatix/elements/phase_masks.py
@@ -147,9 +147,9 @@ class SpatialLightModulator(nn.Module):
             field.spectrum[..., 0, 0].squeeze(),
             *pupil_args,
         )
-        assert (
-            phase.shape == self.shape
-        ), "Provided phase shape should match provided SLM shape"
+        assert phase.shape == self.shape, (
+            "Provided phase shape should match provided SLM shape"
+        )
         phase = wrap_phase(phase, self.phase_range)
         if self.num_bits is not None:
             phase = quantize(phase, 2.0**self.num_bits, range=self.phase_range)

--- a/src/chromatix/field.py
+++ b/src/chromatix/field.py
@@ -347,9 +347,9 @@ class ScalarField(Field):
             assert shape is not None, "Must specify shape if u is None"
             u = jnp.empty((1, *shape, spectrum.size, 1), dtype=jnp.complex64)
         ndim = len(u.shape)
-        assert (
-            ndim >= 5
-        ), "Field must be Array with at least 5 dimensions: (B... H W C 1)."
+        assert ndim >= 5, (
+            "Field must be Array with at least 5 dimensions: (B... H W C 1)."
+        )
         assert u.shape[-1] == 1, "Last dimension must be 1 for scalar fields."
         assert_equal_shape([spectrum, spectral_density])
         spectral_density = spectral_density / jnp.sum(spectral_density)
@@ -408,9 +408,9 @@ class VectorField(Field):
             assert shape is not None, "Must specify shape if u is None"
             u = jnp.empty((1, *shape, spectrum.size, 3), dtype=jnp.complex64)
         ndim = len(u.shape)
-        assert (
-            ndim >= 5
-        ), "Field must be Array with at least 5 dimensions: (B... H W C 3)."
+        assert ndim >= 5, (
+            "Field must be Array with at least 5 dimensions: (B... H W C 3)."
+        )
         assert u.shape[-1] == 3, "Last dimension must be 3 for vectorial fields."
         assert_equal_shape([spectrum, spectral_density])
         spectral_density = spectral_density / jnp.sum(spectral_density)

--- a/src/chromatix/functional/sources.py
+++ b/src/chromatix/functional/sources.py
@@ -198,12 +198,12 @@ def generic_field(
             ``VectorField`` (if False). Defaults to True.
     """
     create = ScalarField.create if scalar else VectorField.create
-    assert (
-        amplitude.ndim >= 5
-    ), "Amplitude must have at least 5 dimensions: (B... H W C [1 | 3])"
-    assert (
-        phase.ndim >= 5
-    ), "Phase must have at least 5 dimensions: (B... H W C [1 | 3])"
+    assert amplitude.ndim >= 5, (
+        "Amplitude must have at least 5 dimensions: (B... H W C [1 | 3])"
+    )
+    assert phase.ndim >= 5, (
+        "Phase must have at least 5 dimensions: (B... H W C [1 | 3])"
+    )
     vectorial_dimension = 1 if scalar else 3
     assert_axis_dimension(amplitude, -1, vectorial_dimension)
     assert_axis_dimension(phase, -1, vectorial_dimension)

--- a/src/chromatix/ops/filters.py
+++ b/src/chromatix/ops/filters.py
@@ -33,9 +33,9 @@ def high_pass_filter(
     Returns:
         The high pass filtered array.
     """
-    assert len(axes) == len(
-        sigma
-    ), "Must specify same number of axes to convolve as elements in sigma"
+    assert len(axes) == len(sigma), (
+        "Must specify same number of axes to convolve as elements in sigma"
+    )
     low_pass_kernel = gaussian_kernel(sigma, shape=kernel_shape)
     # NOTE(gj): 1e-3 effectively gives delta kernel
     delta_kernel = gaussian_kernel((1e-3,) * len(sigma), shape=low_pass_kernel.shape)
@@ -63,9 +63,9 @@ def gaussian_filter(
     Returns:
         The Gaussian filtered array.
     """
-    assert len(axes) == len(
-        sigma
-    ), "Must specify same number of axes to convolve as elements in sigma"
+    assert len(axes) == len(sigma), (
+        "Must specify same number of axes to convolve as elements in sigma"
+    )
     kernel = gaussian_kernel(sigma, shape=kernel_shape)
     kernel = _broadcast_2d_to_spatial(kernel, data.ndim)
     return fourier_convolution(data, kernel, axes=axes)

--- a/src/chromatix/ops/resample.py
+++ b/src/chromatix/ops/resample.py
@@ -59,9 +59,9 @@ def init_plane_resample(
     """
     assert len(out_shape) == 2, "Shape must be tuple of form (H W)"
     out_spacing = jnp.atleast_1d(out_spacing).squeeze()
-    assert (
-        out_spacing.size <= 2
-    ), "Spacing is either a float or array of shape (2,) for non-square pixels"
+    assert out_spacing.size <= 2, (
+        "Spacing is either a float or array of shape (2,) for non-square pixels"
+    )
     if resampling_method == "pool":
 
         def op(x: Array, in_spacing: Union[float, Array]) -> Array:
@@ -77,9 +77,9 @@ def init_plane_resample(
 
         def op(x: Array, in_spacing: Union[float, Array]) -> Array:
             in_spacing = jnp.atleast_1d(in_spacing).squeeze()
-            assert (
-                in_spacing.size <= 2
-            ), "Spacing is either a float or array of shape (2,) for non-square pixels"
+            assert in_spacing.size <= 2, (
+                "Spacing is either a float or array of shape (2,) for non-square pixels"
+            )
             _in_shape, _out_shape = jnp.array(x.shape[:-2]), jnp.array(out_shape)
             scale = in_spacing / out_spacing
             translation = -0.5 * (_in_shape * scale - _out_shape)

--- a/src/chromatix/utils/data.py
+++ b/src/chromatix/utils/data.py
@@ -338,10 +338,10 @@ class RandDiskGenerator:  # TODO avoid overlapping disks
                 the z coordinates.
         """
 
-        assert (
-            len(shape) == 3
-        ), "Shape must specify three dimensions, shape parameter is: {}".format(
-            len(shape)
+        assert len(shape) == 3, (
+            "Shape must specify three dimensions, shape parameter is: {}".format(
+                len(shape)
+            )
         )
         self.N = N
         self.radius = radius

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -11,6 +11,6 @@ def test_fourier_convolution():
 
     result_chromatix = jit(fourier_convolution)(A, B)
     result_scipy = convolve(A, B, method="fft", mode="same")
-    assert np.allclose(
-        result_scipy, result_chromatix, atol=1e-3
-    ), "Fourier convolution not correct"
+    assert np.allclose(result_scipy, result_chromatix, atol=1e-3), (
+        "Fourier convolution not correct"
+    )

--- a/tests/test_zernikes.py
+++ b/tests/test_zernikes.py
@@ -55,9 +55,9 @@ def test_first_ten_zernikes():
             coefficients=[1],
         )
         assert phase.shape == size
-        assert jnp.allclose(
-            phase.squeeze(), expected[idx]
-        ), f"Mismatch in Zernike polynomial {idx}."
+        assert jnp.allclose(phase.squeeze(), expected[idx]), (
+            f"Mismatch in Zernike polynomial {idx}."
+        )
 
 
 def piston(mask):


### PR DESCRIPTION
Pre-commit hooks will help contributors conform to formatting without having to run extra commands for formatting.