### PR TITLE
Fix initialization planewave multiple wavelengths.

### DIFF
--- a/src/chromatix/functional/sources.py
+++ b/src/chromatix/functional/sources.py
@@ -163,7 +163,10 @@ def plane_wave(
     kykx = _broadcast_1d_to_grid(kykx, field.ndim)
     amplitude = _broadcast_1d_to_polarization(amplitude, field.ndim)
     u = amplitude * jnp.exp(1j * jnp.sum(kykx * field.grid, axis=0))
-    field = field.replace(u=u)
+    # There's no spectral dependence so we need to manually put in the spectral axis
+    # hence the ones_like term.
+    field = field.replace(u=u * jnp.ones_like(field.u))
+
     if pupil is not None:
         field = pupil(field)
     return field * jnp.sqrt(power / field.power)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -44,6 +44,17 @@ def test_plane_wave_vectorial(power, amplitude, shape, pupil):
     assert_shape(field.u, (1, *shape, 1, 3))
 
 
+def test_spectral_plane_wave():
+    """Tests the planewave initialisation shapes."""
+    field = cf.plane_wave(
+        (16, 16),
+        0.1,
+        [0.1, 0.532, 1.0],
+        [1.0, 1.0, 1.0],
+    )
+    assert_shape(field.u, (1, 16, 16, 3, 1))
+
+
 @pytest.mark.parametrize(
     "power, z, shape, pupil",
     [


### PR DESCRIPTION
Gia found a bug where the planewave when initialized with multiple wavelengths `L` only has shape `[B, Y, X, 1, 1]`, instead of `[B, Y, X, L, 1]`. Other sources aren't affected as they have a spectrum term in their init. This PR fixes that issue and adds a test for it.