### PR TITLE
[DRAFT] Switching to equinox; overhauling the field.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,12 +130,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# poetry stuff
-poetry.lock
-poetry.toml
-
-# dev folder
-dev/
-
 # DS_store
 .DS_Store

--- a/dev/field.py
+++ b/dev/field.py
@@ -1,0 +1,200 @@
+import abc
+from typing import ClassVar
+
+import equinox as eqx
+import jax.numpy as jnp
+from einops import rearrange
+from jaxtyping import Array, Complex, Float, Real
+
+
+# Abstract fields
+class AbstractField(eqx.Module):
+    u: eqx.AbstractVar[Array]
+    dx: eqx.AbstractVar[Array]
+    spectrum: eqx.AbstractVar[Array] # NOTE: Should we make a spectrum type?
+
+    # Internal for use
+    dims: eqx.AbstractClassVar[dict[str, int]] # NOTE: Turn this into a enum?
+
+    @property
+    @abc.abstractmethod
+    def intensity(self) -> Array:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def grid(self) -> Array: 
+        pass
+
+    @property
+    @abc.abstractmethod
+    def k_grid(self) -> Array:
+        pass
+
+    @property
+    def power(self):
+        area = jnp.prod(self.dx, axis=-1)
+        return area * jnp.sum(self.intensity, axis=(self.dims["y"], self.dims["x"]))
+    
+    @property
+    def spatial_shape(self) -> tuple[int, int]:
+        return self.u.shape[self.dims["y"]], self.u.shape[self.dims["x"]]
+
+    @property
+    def dk(self) -> Array:
+        return 1 / (self.dx * jnp.asarray(self.spatial_shape))
+
+    @property
+    def surface_area(self) -> Array:
+        shape = jnp.array(self.spatial_shape)
+        return self.dx * shape
+
+    @property
+    def phase(self) -> Array:
+        return jnp.angle(self.u)
+
+    @property
+    def amplitude(self) -> Array:
+        return jnp.abs(self.u)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.u.shape
+
+    @property
+    def ndim(self) -> int:
+        return self.u.ndim
+
+    @property
+    def conj(self) -> Array:
+        # TODO: Add replace method?
+        return self.replace(u=jnp.conj(self.u))
+
+    @property
+    def _grid(self) -> Array:
+     N_y, N_x = self.spatial_shape
+     dx = rearrange(self.dx, "... d -> ... 1 1 d")
+     grid = jnp.meshgrid(
+            jnp.linspace(0, (N_y - 1), N_y) - N_y / 2,
+            jnp.linspace(0, (N_x - 1), N_x) - N_x / 2,
+            indexing="ij"
+        )
+     return dx * jnp.stack(grid, axis=-1)
+    
+    @property
+    def _freq_grid(self) -> Array:
+        N_y, N_x = self.spatial_shape
+        dk = rearrange( 1/ self.dx, "... d -> ... 1 1 d")
+        grid = jnp.meshgrid(
+            jnp.fft.fftshift(jnp.fft.fftfreq(N_y)),
+            jnp.fft.fftshift(jnp.fft.fftfreq(N_x)),
+            indexing="ij"
+        )
+        return dk * jnp.stack(grid, axis=-1)
+
+class Spectral(eqx.Module):
+    spectral_density: eqx.AbstractVar[Array] # TODO: is this the right name?
+
+class Scalar(eqx.Module):
+    pass
+
+class Vectorial(eqx.Module):
+
+    @property
+    @abc.abstractmethod
+    def jones_vector(self) -> Array:
+        pass
+
+
+# Actual field
+class CoherentScalarField(AbstractField, Scalar):
+    u: Complex[Array, "*b y x"]
+    dx: Float[Array, "*b 2"]
+    spectrum: Float[Array, "*b 1"]
+
+    dims: ClassVar[dict[str, int]]= {"y": -2, "x": -1}
+
+    def __init__(self, dx: float | Real[Array, "1"] | Real[Array, "2"], spectrum: float, u: Complex[Array, "y x"]):
+        # Parsing u
+        self.u = jnp.asarray(u)
+
+        # Parsing dx 
+        dx = jnp.asarray(dx)
+        match dx.size:
+            case 1:
+                self.dx = jnp.stack([dx, dx])
+            case 2:
+                self.dx = dx
+            case _:
+                raise ValueError(f"dx must be of size 1 or 2, got {dx.size}")
+        
+        # Parsing spectrum
+        self.spectrum = jnp.asarray(spectrum)
+
+    @property
+    def intensity(self) -> Float[Array, "*b y x"]:
+        return jnp.abs(self.u)**2
+
+    @property
+    def grid(self) -> Float[Array, "*b y x d"]:
+        return self._grid 
+
+    @property
+    def k_grid(self) -> Float[Array, "*b y x d"]:
+        # TODO: Technically we're missing a factor 2 pi here!
+        # This should be called fx
+        return self._freq_grid
+    
+
+
+class SpectralCoherentScalarField(AbstractField, Scalar, Spectral):
+    u: Complex[Array, "*b y x l"]
+    dx: Float[Array, "*b #l 2"]
+    spectrum: Float[Array, "*b l"]
+    spectral_density: Float[Array, "*b l"]
+
+    dims: ClassVar[dict[str, int]]= {"y": -3, "x": -2, "l": -1}
+
+    def __init__(self, dx: float | Real[Array, "1"] | Real[Array, "2"], spectrum: Float[Array, "l"], spectral_density: Float[Array, "l"], u: Complex[Array, "y x l"]):
+        # TODO; we need some more shape checking here
+        # Parsing u
+        self.u = jnp.asarray(u)
+
+        # Parsing dx 
+        dx = jnp.asarray(dx)
+        match dx.size:
+            case 1:
+                self.dx = rearrange(jnp.stack([dx, dx]), "c -> 1 c")
+            case 2:
+                self.dx = rearrange(dx, "c -> 1 c")
+            case _:
+                raise ValueError(f"dx must be of size 1 or 2, got {dx.size}")
+        
+        # Parsing spectrum
+        self.spectrum = jnp.asarray(spectrum)
+        self.spectral_density = jnp.asarray(spectral_density)
+
+
+    @property
+    def intensity(self):
+        spectral_density = rearrange(self.spectral_density, "... l -> ... 1 1 l")
+        return spectral_density * jnp.abs(self.u)**2
+
+    @property
+    def grid(self) -> Array:
+        return rearrange(self._grid, "... l y x d-> ... y x l d")
+
+    @property
+    def k_grid(self) -> Array:
+        return rearrange(self._freq_grid, "... l y x d-> ... y x l d")
+        
+    
+class CoherentVectorField(AbstractField, Vectorial):
+    pass
+
+class SpectralCoherentVectorField(AbstractField, Vectorial, Spectral):
+    pass
+
+
+
+

--- a/dev/field.py
+++ b/dev/field.py
@@ -70,6 +70,8 @@ class AbstractField(eqx.Module):
         # TODO: Add replace method?
         return self.replace(u=jnp.conj(self.u))
 
+    # These are standardised grids without empty dimensions;
+    # and they should be reshaped in the actual field
     @property
     def _grid(self) -> Array:
      N_y, N_x = self.spatial_shape
@@ -106,8 +108,15 @@ class Vectorial(eqx.Module):
         pass
 
 
+# These two don't do anything yet.
+class Coherent(eqx.Module):
+    pass
+
+class PartiallyCOherent(eqx.Module):
+    pass
+
 # Actual field
-class CoherentScalarField(AbstractField, Scalar):
+class CoherentScalarField(AbstractField, Scalar, Coherent):
     u: Complex[Array, "*b y x"]
     dx: Float[Array, "*b 2"]
     spectrum: Float[Array, "*b 1"]
@@ -131,6 +140,8 @@ class CoherentScalarField(AbstractField, Scalar):
         # Parsing spectrum
         self.spectrum = jnp.asarray(spectrum)
 
+    # The only functions that need to be implemented are intensity, grid, and k_grid
+
     @property
     def intensity(self) -> Float[Array, "*b y x"]:
         return jnp.abs(self.u)**2
@@ -147,7 +158,7 @@ class CoherentScalarField(AbstractField, Scalar):
     
 
 
-class SpectralCoherentScalarField(AbstractField, Scalar, Spectral):
+class SpectralCoherentScalarField(AbstractField, Scalar, Spectral, Coherent):
     u: Complex[Array, "*b y x l"]
     dx: Float[Array, "*b #l 2"]
     spectrum: Float[Array, "*b l"]
@@ -186,13 +197,15 @@ class SpectralCoherentScalarField(AbstractField, Scalar, Spectral):
 
     @property
     def k_grid(self) -> Array:
+        # TODO: Technically we're missing a factor 2 pi here!
+        # This should be called fx
         return rearrange(self._freq_grid, "... l y x d-> ... y x l d")
         
     
-class CoherentVectorField(AbstractField, Vectorial):
+class CoherentVectorField(AbstractField, Vectorial, Coherent):
     pass
 
-class SpectralCoherentVectorField(AbstractField, Vectorial, Spectral):
+class SpectralCoherentVectorField(AbstractField, Vectorial, Spectral, Coherent):
     pass
 
 

--- a/dev/test_field.py
+++ b/dev/test_field.py
@@ -1,0 +1,64 @@
+import jax
+import jax.numpy as jnp
+from field import CoherentScalarField, SpectralCoherentScalarField
+
+
+# %%
+@jax.jit
+def forward(u):
+    return CoherentScalarField(0.25, 0.532, u) 
+
+field = forward(jnp.ones((512, 512)))
+print("Scalar")
+print(field.intensity.shape)
+print(field.power.shape)
+print(field.grid.shape)
+print(field.k_grid.shape)
+
+# %%
+
+field = jax.vmap(forward)(jnp.ones((5, 512, 512)))
+print("Vmapped scalar")
+print(field.intensity.shape)
+print(field.power.shape)
+print(field.grid.shape)
+print(field.k_grid.shape)
+# %%
+@jax.jit
+def forward(u):
+    return SpectralCoherentScalarField(0.25, [0.1, 0.532, 1.0], [0.2, 0.4, 0.1], u) 
+
+field = forward(jnp.ones((512, 512, 3)))
+print("Spectral")
+print(field.intensity.shape)
+print(field.power.shape)
+print(field.grid.shape)
+print(field.k_grid.shape)
+
+# %%
+
+
+field = jax.vmap(forward)(jnp.ones((5, 512, 512, 3)))
+print("Vmapped Spectral")
+print(field.intensity.shape)
+print(field.power.shape)
+print(field.grid.shape)
+print(field.k_grid.shape)
+
+
+# Current implementation
+print("Stuff that doesn't work in the current implementation")
+import chromatix.functional as cf
+
+@jax.jit
+def forward_chromatix(dx):
+    u = jnp.ones((1, 512, 512, 1, 1))
+    return cf.generic_field(dx, 1.0, 1.0, u, jnp.zeros_like(u))
+
+field = forward_chromatix(0.1)
+field.intensity.shape
+# %%
+field = jax.vmap(forward_chromatix)(jnp.ones((5, 1, 512, 512, 1, 1)))
+field.intensity.shape
+# %%
+field.spectrum

--- a/dev/test_field.py
+++ b/dev/test_field.py
@@ -1,12 +1,21 @@
 import jax
 import jax.numpy as jnp
-from field import CoherentScalarField, SpectralCoherentScalarField
+from field import AbstractField, CoherentScalarField, SpectralCoherentScalarField
 
+# Testing grid stuff
+def l2_sq_norm(x):
+    return jnp.sum(jnp.abs(x)**2)
+
+def phase_change(field: AbstractField , z, n=1.0) -> AbstractField:
+    L_sq = field.spectrum * z / n
+    phase = (jnp.pi / L_sq) * l2_sq_norm(field.grid)
+    return field.replace(u=field.u * jnp.exp(1j * phase)) # showing that replace works 
 
 # %%
 @jax.jit
 def forward(u):
-    return CoherentScalarField(0.25, 0.532, u) 
+    field = CoherentScalarField(0.25, 0.532, u) 
+    return phase_change(field, 1.0)
 
 field = forward(jnp.ones((512, 512)))
 print("Scalar")
@@ -26,7 +35,8 @@ print(field.k_grid.shape)
 # %%
 @jax.jit
 def forward(u):
-    return SpectralCoherentScalarField(0.25, [0.1, 0.532, 1.0], [0.2, 0.4, 0.1], u) 
+    field = SpectralCoherentScalarField(0.25, [0.1, 0.532, 1.0], [0.2, 0.4, 0.1], u) 
+    return phase_change(field, 1.0)
 
 field = forward(jnp.ones((512, 512, 3)))
 print("Spectral")
@@ -37,7 +47,6 @@ print(field.k_grid.shape)
 
 # %%
 
-
 field = jax.vmap(forward)(jnp.ones((5, 512, 512, 3)))
 print("Vmapped Spectral")
 print(field.intensity.shape)
@@ -46,9 +55,15 @@ print(field.grid.shape)
 print(field.k_grid.shape)
 
 
+
+
+
+
+
 # Current implementation
 print("Stuff that doesn't work in the current implementation")
 import chromatix.functional as cf
+
 
 @jax.jit
 def forward_chromatix(dx):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,15 @@ description = "Differentiable wave optics library using JAX"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
-dependencies = ["jax >= 0.4.1", "einops >= 0.6.0", "flax >= 0.6.3", "chex>=0.1.5", "optax >=0.1.4", "scipy >= 1.10.0"]
+dependencies = [
+    "jax >= 0.4.1",
+    "einops >= 0.6.0",
+    "flax >= 0.6.3",
+    "chex>=0.1.5",
+    "optax >=0.1.4",
+    "scipy >= 1.10.0",
+    "equinox>=0.11.12",
+]
 version = "0.3.0"
 
 [project.optional-dependencies]
@@ -25,3 +33,8 @@ extend-select = ["I"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
+
+[tool.uv]
+dev-dependencies = [
+    "ruff>=0.9.0",
+]


### PR DESCRIPTION
## The current situation

Currently our field is based off Flax's `struct.PyTreeNode`, and internally everything has the same 5D shape: `[batch height width wavelength scalar/vector]`. Additionally, due to issues with `jit` and `vmap`, `dx`, and `spectrum` are not part of the pytree, and they thus don't get transformed by vmap. For example

```
@jax.jit
def forward_chromatix(dx):
    u = jnp.ones((1, 512, 512, 1, 1))
    return cf.generic_field(dx, 1.0, 1.0, u, jnp.zeros_like(u))
```
throws an error. Internally this results in a lot of complicated and messy shape wrangling (separate access methods for every parameter), and externally we have lots of empty axes for end users. If you just want to simulate a scalar single wavelength (which is the majority of users), why do they need to deal with 5D tensors of which only 2 axes are non-empty?

In short, the problems are:
1. Returning a field from a vmapped / jitted function tends to throw of weird errors. 
2. A lot of empty axes.
3. Internal complexity.

TL;DR: Lots of confusion for users.

## Proposed solution

This draft PR proposes a way around this, *without* (large) breaking changes. The main ideas are:

1) Switch to [equinox](https://github.com/patrick-kidger/equinox) modules, as it makes life easier, and contains a lot of useful goodies.
2) Make more field types, which all have different shapes, depending on amount of wavelengths, scalar vs vector, etc.
3) Get rid of the batch axis, as this resulted in a lot of shape wrangling.
4) Every class has an `dim` attributes mapping names to axis, indicating where the axis is. This is a bare-bones replacement for named axes, which unfortunately doesn't seem to be happening in the jax ecosystem.
5) Minorly, this PR also adds in some jaxtyping for shape annotation. 

Instead of `ScalarField` and `VectorField` - we now have fields like `ScalarCoherentField` - shape `[h w]`, or `SpectralScalarCoherentField`, of shape `[h w l]`. Despite the changes in the shape, they are still internally consistent, so we can use the same function on these two fields, for example:

```
def phase_change(field: AbstractField , z, n=1.0) -> AbstractField:
    L_sq = field.spectrum * z / n
    phase = (jnp.pi / L_sq) * l2_sq_norm(field.grid)
    return field.replace(u=field.u * jnp.exp(1j * phase)) # showing that replace works 

@jax.jit
def forward(u):
    field = CoherentScalarField(0.25, 0.532, u) 
    return phase_change(field, 1.0)

# This all works!
field = jax.vmap(forward)(jnp.ones((5, 512, 512)))
print(field.intensity.shape) # [5, 512, 512]
print(field.power.shape) # [5, ]
print(field.grid.shape) # [5, 512, 512, 2]
print(field.k_grid.shape) # [5, 512, 512, 2]

# But this too!
@jax.jit
def forward(u):
    field = SpectralCoherentScalarField(0.25, [0.1, 0.532, 1.0], [0.2, 0.4, 0.1], u) 
    return phase_change(field, 1.0)

field = jax.vmap(forward)(jnp.ones((5, 512, 512, 3)))
print(field.intensity.shape) #[5, 512, 512, 3]
print(field.power.shape) #[5, 3], power / wavelength
print(field.grid.shape) #[5, 512, 512, 1, 2] # 1 because all dx are the same
print(field.k_grid.shape) #[5, 512, 512, 1, 2]
```

The full code and testcases can be found in the `dev` folder. I still need to add more test cases, but it seems this approach to do everything we'd like, fix all our issues, simplify code and do so without breaking changes. I'll add more stuff slowly, but would be happy to get some feedback here, @diptodip @ebezzam!

