### PR TITLE
Update readthedocs build.

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 


### PR DESCRIPTION
Got an email from readthedocs that we need to update our ubuntu image because 20.04 is being deprecated; switched to 24.04 per the instructions.