### PR TITLE
Fix multi-z broadcasting crash in asm_propagate(..., bandlimit=True)

### DIFF
--- a/src/chromatix/functional/propagation.py
+++ b/src/chromatix/functional/propagation.py
@@ -556,10 +556,14 @@ def compute_asm_propagator(
     if bandlimit:
         # Table 1 of "Shifted angular spectrum method for off-axis numerical
         # propagation" (2010) by Matsushima in vectorized form
-        k_limit_p = ((shift_yx + 1 / (2 * field.df)) ** (-2) * z**2 + 1) ** (
+        # `z` carries trailing singletons for the spatial dims but not for the
+        # trailing length-2 yx-vector axis of `field.df` / `shift_yx`. Add it so
+        # the cutoffs broadcast against `field.f_grid` for multi-element `z`.
+        z_bl = z[..., None] if z.ndim > 0 else z
+        k_limit_p = ((shift_yx + 1 / (2 * field.df)) ** (-2) * z_bl**2 + 1) ** (
             -1 / 2
         ) / field.broadcasted_wavelength
-        k_limit_n = ((shift_yx - 1 / (2 * field.df)) ** (-2) * z**2 + 1) ** (
+        k_limit_n = ((shift_yx - 1 / (2 * field.df)) ** (-2) * z_bl**2 + 1) ** (
             -1 / 2
         ) / field.broadcasted_wavelength
         k0 = (1 / 2) * (

--- a/tests/test_propagate.py
+++ b/tests/test_propagate.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -204,3 +205,50 @@ def test_transform_multiple():
         field_after_first_propagation, z=10.0, n=1, pad_width=256
     )
     assert field_after_second_propagation.intensity.squeeze()[256, 256] != 0.0
+
+
+@pytest.mark.parametrize("shift_yx", [(0.0, 0.0), (3.0, -2.0)])
+def test_asm_multi_z_bandlimit_matches_vmap(shift_yx):
+    """Multi-z ``asm_propagate(..., bandlimit=True)`` must broadcast and match vmap.
+
+    Regression test for a broadcasting bug in ``compute_asm_propagator``: when
+    ``z`` is a multi-element array, the bandlimit branch built its cutoffs
+    without the trailing yx-vector singleton, so ``field.f_grid - k0`` raised a
+    ``TypeError`` (incompatible shapes). The batched result must (i) be finite
+    and have shape ``(n_z, Y, X)`` and (ii) equal a ``jax.vmap`` over the proven
+    scalar bandlimit path.
+    """
+    shape = (128, 128)
+    spacing = 0.5
+    pad_width = 128
+    z = jnp.array([50.0, 100.0, 150.0])
+
+    field = cf.plane_wave(shape, spacing, spectrum)
+    out = cf.asm_propagate(
+        field,
+        z,
+        n,
+        pad_width=pad_width,
+        mode="same",
+        bandlimit=True,
+        shift_yx=shift_yx,
+    )
+    u_batched = jnp.squeeze(out.u)
+
+    assert jnp.all(jnp.isfinite(jnp.abs(u_batched)))
+    assert u_batched.shape == (z.size, *shape)
+
+    def scalar_propagate(zi):
+        single = cf.plane_wave(shape, spacing, spectrum)
+        return cf.asm_propagate(
+            single,
+            zi,
+            n,
+            pad_width=pad_width,
+            mode="same",
+            bandlimit=True,
+            shift_yx=shift_yx,
+        ).u
+
+    u_vmap = jnp.squeeze(jax.vmap(scalar_propagate)(z))
+    assert jnp.array_equal(u_batched, u_vmap)


### PR DESCRIPTION
## Summary

`asm_propagate` is documented to accept either a scalar `z` or a 1-D array of `z` values (in which case it adds a batch axis and propagates to several planes at once). That works fine with `bandlimit=False`, but with `bandlimit=True` an array `z` raises a `TypeError`. The cause is a single missing broadcast axis in `compute_asm_propagator`.

## Reproduction

```python
import jax.numpy as jnp
from chromatix.functional import plane_wave, phase_change, asm_propagate

N = 64
f = plane_wave((N, N), dx=1.875, spectrum=0.355)
f = phase_change(f, jnp.zeros((N, N)))
z = jnp.array([5000.0, 6000.0, 7000.0])   # 3 planes

asm_propagate(f, z, 1.0, pad_width=N // 2, bandlimit=True, mode="same")
# TypeError: sub got incompatible shapes for broadcasting: (128, 128, 2), (3, 1, 2)
```

Scalar `z` works with `bandlimit=True`, and the same array `z` works with `bandlimit=False`, only a z array and BLAS breaks.

## Root cause

Inside `compute_asm_propagator`, an array `z` gets reshaped for batching:

```python
z = _broadcast_1d_to_innermost_batch(z, field.spatial_dims)
```

For a 2-D field this gives `z` the shape `(n_z, 1, 1)` — one trailing singleton for each of the two spatial dimensions. But `field.f_grid` has shape `(Y, X, 2)`: there's an extra trailing length-2 axis holding the `(y, x)` frequency vector, and `field.df` / `shift_yx` carry that axis too. `z` doesn't get a singleton for it.

That's fine on the non-bandlimit path, because it collapses the length-2 axis before it ever multiplies by `z`:

```python
delay = ... l2_sq_norm(field.f_grid - kykx)   # (Y, X, 2) -> (Y, X)
# z (n_z, 1, 1) * delay (Y, X)  ->  (n_z, Y, X)   clean
```

The bandlimit branch is the opposite order. It builds frequency cutoffs from `field.df` / `shift_yx` (still shape `(2,)`) and multiplies in `z**2` while that length-2 axis is still around. The cutoffs come out as `(n_z, 1, 2)`, and then:

```python
jnp.abs(field.f_grid - k0) <= k_max   # (Y, X, 2) vs (n_z, 1, 2)
```

The trailing `2` lines up and `X` broadcasts against `1`, but `Y` (128) collides with `n_z` (3) and you get the `TypeError`.

So `z` is exactly one trailing singleton short for that length-2 axis. The regular ASM path doesn't fail because it reduces the axis first; the BLAS path multiplies first, so it does.

## Fix

Give `z` the one missing trailing singleton, inside the `if bandlimit:` branch only:

```python
z_bl = z[..., None] if z.ndim > 0 else z
```

and use `z_bl` in `k_limit_p` / `k_limit_n`. The cutoffs then broadcast as `(n_z, 1, 1, 2)` against `field.f_grid (Y, X, 2)` and reduce to `(n_z, Y, X)`. Everything downstream (`k0`, `k_width`, `k_max`, `H_filter`) inherits the new axis through the cutoffs, and the plain `z` used elsewhere is left alone.

The guard is `z.ndim > 0`, not `z.size > 1`, so a scalar / 0-d `z` is byte-identical to before (a true no-op), and a shape-`(1,)` `z` still reduces to the non-batched result. `z.ndim` is static at trace time, so this doesn't cause a JIT retrace or affect `jax.grad`.

## Verification

- The batched `bandlimit=True` result is bit-exact against `jax.vmap` over the scalar `bandlimit=True` path (`jnp.array_equal` is `True`, `max|Δ| = 0`), for on-axis `shift_yx=(0,0)` and off-axis `(3,-2)`, with and without `remove_evanescent`, and for ScalarField` / `VectorField` / `ChromaticVectorField`. (vmap over the scalar path is the right reference since both run the same batched FFT.)
- Scalar `z` output is byte-identical before and after the change.
- The added regression test fails on `main` with `TypeError: sub got incompatible shapes for broadcasting` and passes after the fix.

The new test lives in `tests/test_propagate.py` (see Files changed). The patch and test pass `ruff format --check` and `ruff check`.
